### PR TITLE
Fix Getting Started path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ in OCaml.  It builds on top of the technology and lessons learned from
 
 # Getting Started
 
-The [Getting Started with Bonsai](./docs/getting_started/index.md)
+The [Getting Started with Bonsai](./docs/getting_started/open_source/index.md)
 guide is good if you're new to web development entirely or just want
 to see a walkthrough of a couple simple example apps.
 


### PR DESCRIPTION
It seems that https://github.com/janestreet/bonsai/commit/6e62a5a6d9fdc621cd5cf2ac8d264720829814d2 adds `/docs/getting_started/open_source/index.md` and the file `/docs/getting_started/index.md` hasn't been published since the "Getting Started" link was inserted in README with this commit <https://github.com/janestreet/bonsai/commit/221df1ab368c351064fbdcaf3bb7e3fb7c7762c8>.