### PR TITLE
[janestreet/bonsai#28] Fix broken link in effect chapter

### DIFF
--- a/docs/guide/05-effect.md
+++ b/docs/guide/05-effect.md
@@ -186,4 +186,4 @@ let on_submit (contents : string) : unit Vdom.Effect.t =
 ```{=html}
 </iframe>
 ```
-Next, read the [chapter on testing](../blogs/testing.md).
+On to [Chapter 7: Flow](./07-flow.md).


### PR DESCRIPTION
Signed-off-by: Samuel Eisenhandler <sgeisenhandler@gmail.com>

The effect chapter had a broken link to the testing blog post. This replaces it with a link to the flow chapter which appears after the effect chapter in the navigation bar.

