### PR TITLE
Documentation Feedback

### DIFF
--- a/docs/guide/00-introduction.md
+++ b/docs/guide/00-introduction.md
@@ -11,21 +11,19 @@ degree, how Bonsai works under the hood. We hope that the latter will
 equip you with the necessary knowledge to tune the performance of your
 applications.
 
-# Web Apps at 10,000 Feet
+# Functional Web Apps at 10,000 Feet
 
-The browser understands three languages: Javascript, HTML, CSS. Jane
-Street programmers only understand one language: OCaml. Thus, we've made
-it possible to write all three of the browser languages using OCaml.
+Fundamentally, a web UI shows you a *view* (the part you can see) based
+on a *model* (structured input data and state). You interact with
+the UI by clicking buttons, entering text, scrolling, etc; in response,
+a *controller* (control logic) updates the *model*, which recalculates
+the *view*. Rinse and repeat.
 
--   `js_of_ocaml` is an OCaml-to-Javascript compiler.
--   `virtual_dom` is a library for building values that represent a
-    chunk of HTML.
--   `css_gen` is a library for writing CSS-styles in a type safe manner.
+This paradigm, [called MVC](https://www.freecodecamp.org/news/model-view-controller-mvc-explained-through-ordering-drinks-at-the-bar-efcba6255053/),
+is useful because it lets us design web UIs using the functional 
+programming patterns we know and love.
 
-The CSS situation is a little more nuanced, since we actually recommend
-writing CSS directly using `ppx_css`.
-
-A user interface is a function from *data* to *view*. In types:
+A user interface is a function from *model* to *view*:
 
 ```{=html}
 <!-- $MDX skip -->
@@ -34,21 +32,41 @@ A user interface is a function from *data* to *view*. In types:
 (* Virtual_dom.Vdom.Node.t represents your applications view *)
 open Virtual_dom
 
-val ui : Your_input_type_here.t -> Vdom.Node.t
+val ui : 'Your_input_type_here.t' -> Vdom.Node.t
+
+(* A simple example in pseudocode. We'll explain real syntax later. *)
+let ui name = 
+    <div>Hello, {name}!</div>
 ```
 
-It's easy to write composable views with such functions, since all you
-need to return is a plain old OCaml value. A small amount of boilerplate
-can turn this function into a simple web app that continuously displays
-the result of the function.
+User interactions, `setTimeout` / `setInterval` calls, and RPC server calls
+are just *side effects* in an otherwise pure function. From monads/applicatives
+to algebraic effects, we have plenty of tools to cleanly deal with those.
 
-Of course, this is a huge simplification; in a real app, you usually
-want:
+It's easy to write composable views with this paradigm, since we can represent
+the UI logic and view output as plain old OCaml functions and values.
+A small amount of boilerplate can turn our ui into a simple web app that
+continuously displays the result of the computation.
+
+# Web Apps with Bonsai
+
+The browser understands three languages: Javascript, HTML, CSS. Jane
+Street programmers only understand one language: OCaml. Thus, we've made
+it possible to write all three of the browser languages using OCaml.
+
+-   `js_of_ocaml` is an OCaml-to-Javascript compiler.
+-   `virtual_dom` is a library for building values that represent a
+    chunk of HTML.
+-   `css_gen` is a library for writing CSS styles in a type safe manner.
+
+Bonsai builds on `virtual_dom` to provide:
 
 -   *Interactivity*, so the user can click on, type into, and navigate
     through things.
 -   *Incrementality*, so that large amounts of highly dynamically data
     can be displayed without the interface lagging.
+-   *State management* primitives, which allow you to build complex,
+    interdependent apps in a clean, type-safe way.
 
 Bonsai provides these features while still encouraging the composition
 and abstraction properties of regular OCaml code. Bonsai wants you to
@@ -75,6 +93,10 @@ and [3](./03-state.md).
 
 # The Underlying Machinery
 
+<!--
+Maybe we should consider including links to more info about incremental
+and diff-and-patch vdom. 
+-->
 The incrementality in Bonsai comes from the `Incremental` library. When
 a web page loads, Bonsai compiles the top-level
 `Vdom.Node.t Computation.t` into something akin to `Vdom.Node.t Incr.t`.

--- a/docs/guide/00-introduction.md
+++ b/docs/guide/00-introduction.md
@@ -45,7 +45,7 @@ to algebraic effects, we have plenty of tools to cleanly deal with those.
 
 It's easy to write composable views with this paradigm, since we can represent
 the UI logic and view output as plain old OCaml functions and values.
-A small amount of boilerplate can turn our ui into a simple web app that
+A small amount of boilerplate can turn our UI into a simple web app that
 continuously displays the result of the computation.
 
 # Web Apps with Bonsai
@@ -59,7 +59,7 @@ it possible to write all three of the browser languages using OCaml.
     chunk of HTML.
 -   `css_gen` is a library for writing CSS styles in a type safe manner.
 
-Bonsai builds on `virtual_dom` to provide:
+Bonsai adds onto `virtual_dom`, providing:
 
 -   *Interactivity*, so the user can click on, type into, and navigate
     through things.
@@ -95,7 +95,8 @@ and [3](./03-state.md).
 
 <!--
 Maybe we should consider including links to more info about incremental
-and diff-and-patch vdom. 
+and diff-and-patch vdom. I like the Mithril.js docs on this:
+https://mithril.js.org/vnodes.html
 -->
 The incrementality in Bonsai comes from the `Incremental` library. When
 a web page loads, Bonsai compiles the top-level

--- a/docs/guide/02-dynamism.md
+++ b/docs/guide/02-dynamism.md
@@ -1,40 +1,78 @@
 # 02 - Dynamism
 
-Dynamism is central to engaging applications: as the state of the world
-changes, so should the UI.
-
 The previous chapter introduced an immutable view type, `Vdom.Node.t`
 along with the idea that the UI is a function from data to view. For
-large and dynamic input data, this function is expensive and must run
-quite often. To keep up with quickly changing data, we would like to
+large and dynamic input data, this function can be expensive and must run
+quite often. To keep up with quickly changing inputs, we would like to
 only re-compute the parts of the view that depend on newly changed data.
 
-This chapter takes a detour from the theme of computing web UIs to
-investigate the core Bonsai abstractions. It may be surprising to know
-that Bonsai isn't specialized for user interfaces; rather, it answers
-the very generic question of how to build composable incremental
-state-machines. As it turns out, incremental state-machines are a great
-abstraction for building UI!
+In this chapter, we'll:
+
+- Explain the core Bonsai abstractions
+- Learn how to use `let%sub` and `let%arr` operators to write Bonsai components
+- Introduce a primitive for state
+- See how Bonsai computations can use data from the outside world
+- Discuss Bonsai more generally, beyond web UIs
+
+# Values and computations
+
+Bonsai is all about constructing incremental state machine graphs.
+A good analogy to help understand Bonsai is that of the spreadsheet.
+From our blog post introducing our [Incremental library](https://blog.janestreet.com/introducing-incremental/):
+
+> In a spreadsheet, each cell contains either simple data, or an equation that
+> describes how the value in this cell should be derived from values in other cells.
+> Collectively, this amounts to a graph-structured computation, and one of the critical
+> optimizations in Excel is that when some of the cells change, Excel only recomputes
+> the parts of the graph that depend on those changed cells.
+
+Bonsai is built around 2 fundamental types:
+
+`'a Value.t` is like a spreadsheet cell. It can contain simple data or the output of some formula over other cells.
+Critically for performance, if backed by a formula, it will only be recalculated if/when an input changes.
+In Bonsai, any given `'a Value.t` is an instance of a component, such as a particular bit of vdom, piece of state,
+or a combination of other `'a Value.t`s.
+
+`'a Computation.t` is like the formula backing a spreadsheet cell. You can use the same formula in various cells,
+and they will all function independently of each other. In Bonsai, it's the definition of a component, and how it's
+composed of other components.
+
+This can be difficult to grasp, so here's a few more analogies:
+
+- An `'a Computation.t` is like the code for a function. A corresponding `'a Value.t` is like the memory cell containing the output of that function.
+- An `'a Value.t` is an incremental computation that produces a value of type `'a`. An `'a Computation.t` is the structure/definition of that computation.
 
 ```{=html}
 <aside>
 ```
-This chapter is more complicated than we might like due to a
-longstanding quirk of Bonsai's architecture. We'll begin by describing
-the more ideal way to think about Bonsai, and then we'll explain why it
-isn't quite accurate.
+If you're familiar with class-based React, this pattern isn't that different.
+Classes define the structure and logic of components, and can use other classes in their implementation.
+They are like `'a Computation.t`.
+
+But at runtime, you're dealing with *instances* of components, which are created with JSX or `React.createElement()`.
+These component instances have a lifecycle, and their view will be recomputed many times as state/input changes.
+They are like `'a Value.t`.
 ```{=html}
 </aside>
 ```
-# Values and computations
 
-Bonsai is all about constructing incremental state machine graphs. A
-`'a Value.t` is a node in a graph that represents a `'a` that changes
-over time. A `'a Computation.t` is an entire graph that might contain
-many `Value.t` of different types, but culminates in a `'a Value.t`. The
-motivation for having two types will be thoroughly explored later, but
-let us start with something basic: building a graph that computes a
+The motivation for having two types will be thoroughly explored at the end of this chapter.
+For now, we'll learn how we can use these types to build Bonsai components.
+
+# Writing Bonsai with `let%arr` and `let%sub`
+
+Let us start with something basic: defining a computation that computes a
 value that depends on two other values.
+
+
+```{=html}
+<aside>
+```
+If you're not familiar with the [`ppx_let`](https://github.com/janestreet/ppx_let) monadic let-binding style,
+read [this article](https://blog.janestreet.com/let-syntax-and-why-you-should-use-it/) for an intro.
+```{=html}
+</aside>
+```
 
 ```{=html}
 <!-- $MDX file=../../examples/bonsai_guide_code/dynamism_examples.ml,part=juxtapose_part_1 -->
@@ -49,18 +87,20 @@ let juxtapose_digits ~(delimiter : string) (a : int Value.t) (b : int Value.t)
 ;;
 ```
 
-The two phrases `a = a` and `b = b` may look a little silly, but they
-are necessary. The expression on the right-hand side of both bindings in
-the `let%arr` has type `int Value.t`, but the pattern on the left hand
-side is a plain old `int` that we can freely pass to `Int.to_string`. So
-`let%arr` is useful for "unwrapping" the data inside a `Value.t` so that
-we can access it for a limited scope.
+In short, `let%arr` creates a new `'b Computation.t` from:
 
-The type of the entire `let%arr` expression, which includes the stuff on
+- Some `'a Value.t`s, which will be incremental inputs to this computation, when instantiated
+- An implementation function (`'a -> 'b`), which maps the "unwrapped" raw OCaml input values to the output of the computation
+
+Here, `a = a and b = b` means that the `a` and `b` `'int Value.t`s will be unwrapped,
+and available in the implementation function as `a` and `b` `int`s respectively.
+
+The type of this entire `let%arr` expression, which includes the stuff on
 both sides of `in`, is `string Computation.t` rather than
-`string Value.t`. This means that the result is a graph and not a node
-in a graph. To obtain the final node of a `Computation.t` graph, we can
-use a `let%sub` expression.
+`string Value.t`. This means that the we've defined a blueprint for an incremental computation,
+not an instance of the computation.
+
+To instantiate our new component for use in another computation, we can use `let%sub`:
 
 ```{=html}
 <!-- $MDX file=../../examples/bonsai_guide_code/dynamism_examples.ml,part=juxtapose_part_2 -->
@@ -68,33 +108,47 @@ use a `let%sub` expression.
 ``` ocaml
 let _juxtapose_and_sum (a : int Value.t) (b : int Value.t) : string Computation.t =
   let%sub juxtaposed = juxtapose_digits ~delimiter:" + " a b in
+  (* Within this scope, `val juxtaposed: string Value.t` *)
   let%sub sum =
     let%arr a = a
     and b = b in
     Int.to_string (a + b)
   in
+  (* Computations don't NEED to be defined in separate declarations.
+   * In the few lines above, we've defined and instantiated
+   * an inline `string Computation.t` into a `string Value.t`. *)
   let%arr juxtaposed = juxtaposed
   and sum = sum in
   juxtaposed ^ " = " ^ sum
 ;;
 ```
 
-We provide a computation and `let%sub` provides a name we can use to
-refer to the result node of that computation. In the first `let%sub`
-above, the computation is `juxtapose_digits a b` and the name is
-`juxtaposed`. The important thing about using `let%sub` is that
-`juxtaposed` has type `string Value.t`, so we can freely use it in
-`let%arr` expressions.
+`let%sub` takes an `'a Computation.t` and instantiates it into an `'a Value.t`,
+which **must** then be used to construct a new `'b Computation.t`.
+
+In the example above, we used `let%sub` to instantiate the `string Value.t`s
+`sum` and `juxtaposed`, and then used `let%arr` to create a new computation with
+those values as inputs. This is a common pattern you'll see in most Bonsai components.
 
 A subtle, yet extremely important aspect of `let%sub` is that it makes a
-copy of the input computation, and the node that the name refers to is
-the result node of that copy, rather than of the original. This means
-that if you use `let%sub` twice on the same computation, you get access
-to the result nodes for two independent copies of the same graph. All
-we've encountered so far are pure function computations constructed with
-`let%arr`, so having multiple copies of a graph is useless, since all
-the copies will always be producing identical results. The ability to
-copy is useful when computations contain internal state.
+copy of the input computation. This means that if you use `let%sub` twice on the
+same `'a Computation.t`, you get the result nodes for two **independent** incremental computations.
+All we've encountered so far are pure function computations constructed with
+`let%arr`, so having multiple copies of a graph doesn't matter: all
+the copies will always be producing identical results. Copying vs non-copying behavior is crucial
+when computations contain internal state.
+
+
+```{=html}
+<aside>
+```
+Theoretically, `Value.t` is an Applicative, meaning that you can also use a `Value.map` operator
+in addition to the `arr` and `sub` we've covered. In 99.9% of cases, we DO NOT recommend using it,
+as it's easy to accidentially duplicate work. See [this blog post](../blogs/letsub.mdx) for more details.
+```{=html}
+</aside>
+```
+# State in Bonsai
 
 The following example demonstrates how to use `Bonsai.state`, a
 primitive computation for introducing internal state to a computation.
@@ -123,10 +177,14 @@ let (counter_button : Vdom.Node.t Computation.t) =
 <iframe data-external="1" src="https://bonsai:8535#counter_button">
 ```
 ```{=html}
-</iframe>
+</iframe>     
 ```
-Now we can illustrate the power of being able to instantiate a component
-twice. The following code demonstrates that we can use `let%sub` on
+
+Note that `val counter_button: Vdom.Node.t Computation.t`, since the incrementally
+computed "output" is the virtual-DOM for the counter.
+
+Now we can see the significance of being able to instantiate a component
+multiple times. The following code demonstrates that we can use `let%sub` on
 `counter_button` to get three independent counters.
 
 ```{=html}
@@ -150,24 +208,23 @@ let (three_counters : Vdom.Node.t Computation.t) =
 ```{=html}
 </iframe>
 ```
-Every time we instantiate `counter_button` with `let%sub`, we get a
-`Vdom.Node.t Value.t` that represents the final result node of a copy of
-the `counter_button` computation graph. We use `Vdom.Node.div` to build
+
+Every time we instantiate `counter_button` with `let%sub`, we get an
+independent `Vdom.Node.t Value.t`. We use `Vdom.Node.div` to build
 a user interface that contains all three buttons so the user can click
 on them; however, first we need to use `let%arr` to get access to the
 view inside each counter graph node.
 
 The role of `let%sub` in Bonsai is similar to the `new` keyword in an
 object-oriented programming language. Just like `new` makes a brand new
-copy of the specified class with its own independent mutable fields, so
-also does `let%sub` make a brand new copy of the specified computation
+copy of the specified class with its own independent mutable fields, 
+`let%sub` makes a brand new copy of the specified computation
 with its own independent internal state. In addition, just like `new`
 usually yields a reference/pointer (in languages like C# or Java)
-instead of the data itself, so also does `let%sub` yield merely the
-result node of the newly copied graph instead of the graph itself.
+instead of the data (type `'a`) itself,`let%sub` yields an `'a Value.t`.
 
 We've introduced two basic kinds of computations - state, which may be
-introduced by `Bonsai.state`, and work, which may be introduced by
+introduced by `Bonsai.state`, and work/logic, which may be introduced by
 `let%arr`. While these are certainly the most important, Bonsai provides
 primitive computations for a few other things, such as time-varying and
 edge-triggering computations.
@@ -177,122 +234,23 @@ computations from smaller ones - `let%sub`. Part of the learning curve
 of building Bonsai apps is getting comfortable composing together a
 bunch of little computations.
 
-# The scary side of values
-
-The previous section intentionally did not explain that `Value.t` is an
-applicative, which means that it works with the `let%map` syntax, in
-addition to the `let%arr` syntax we've already introduced. The
-difference between the two is very small: `let%arr` expands to the
-expansion of `let%map`, except it wraps the entire thing in a call to
-`return`. The following
-
-`ocaml skip let f (x : int Value.t) : int Computation.t =   let%arr x = x in   x + 1`
-
-expands to
-
-`ocaml skip let f (x : int Value.t) : int Computation.t =   (let%arr x = x in      x + 1)`
-
-which further expands to
-
-`ocaml skip let f (x : int Value.t) : int Computation.t =   return (Value.map x ~f:(fun x -> x + 1))`
-
-The `Value.t` applicative interface is scary because re-using the result
-of a `let%map` expression causes the work that it represents to be
-duplicated. Consider the following computation.
-
-```{=html}
-<!-- $MDX file=../../examples/bonsai_guide_code/dynamism_examples.ml,part=problem_with_map_part_1 -->
-```
-``` ocaml
-let component (xs : int list Value.t) : string Computation.t =
-  let sum =
-    let%map xs = xs in
-    List.fold xs ~init:0 ~f:( + )
-  in
-  let average =
-    let%map sum = sum
-    and xs = xs in
-    let length = List.length xs in
-    if length = 0 then 0 else sum / length
-  in
-  let%arr sum = sum
-  and average = average in
-  [%string "sum = %{sum#Int}, average = %{average#Int}"]
-;;
-```
-
-We would like this computation to only do the work of computing `sum`
-once; however, every usage of `sum` entails an iteration through the
-list. Note that the final result depends on `sum` directly, but also
-indirectly through `average`; this means that `sum` is computed twice in
-order to produce the formatted string.
-
-This explanation seems to contradict the explanation in the beginning of
-this chapter that computations are graphs and values are nodes in the
-graph. The truth is that values are also graphs, and re-using a value
-entails using another copy of that value's graph, thus duplicating any
-work contained in the graph. To avoid this work duplication, we can
-instantiate the value with `let%sub`, but since `let%sub` only
-instantiates computations, we must wrap the `let%map` inside a call to
-`return`. For consistency and robustness, we'll apply this
-transformation to `average` as well, even though it is only used once.
-
-```{=html}
-<!-- $MDX file=../../examples/bonsai_guide_code/dynamism_examples.ml,part=problem_with_map_part_2 -->
-```
-``` ocaml
-let component (xs : int list Value.t) : string Computation.t =
-  let%sub sum =
-    return
-      (let%map xs = xs in
-       List.fold xs ~init:0 ~f:( + ))
-  in
-  let%sub average =
-    return
-      (let%map sum = sum
-       and xs = xs in
-       let length = List.length xs in
-       if length = 0 then 0 else sum / length)
-  in
-  return
-    (let%map sum = sum
-     and average = average in
-     [%string "sum = %{sum#Int}, average = %{average#Int}"])
-;;
-```
-
-Before the introduction of `let%arr`, this was the idiomatic way of
-using Bonsai. However, now that `let%arr` exists, we can transform the
-above code into the following, exactly equivalent, computation:
-
-```{=html}
-<!-- $MDX file=../../examples/bonsai_guide_code/dynamism_examples.ml,part=problem_with_map_part_3 -->
-```
-``` ocaml
-let component (xs : int list Value.t) : string Computation.t =
-  let%sub sum =
-    let%arr xs = xs in
-    List.fold xs ~init:0 ~f:( + )
-  in
-  let%sub average =
-    let%arr sum = sum
-    and xs = xs in
-    let length = List.length xs in
-    if length = 0 then 0 else sum / length
-  in
-  let%arr sum = sum
-  and average = average in
-  [%string "sum = %{sum#Int}, average = %{average#Int}"]
-;;
-```
-
-While the `Value.t` applicative can have surprising behavior, if you
-restrict yourself to only use `let%sub` and `let%arr`, then you won't
-ever accidentally duplicate work.
+<!-- With the changes I'm proposing above, the graph vs node analogy
+no longer applies. Since this article is getting pretty long, I've instead
+added an aside after `sub`, linking to the `letsub` blog article for an explanation of
+why `sub` + `arr` is generally better than `map`.
+ -->
 
 # Inputs to the graph
 
-Dynamic data flows into the graph through `'a Var.t`, the third main
+Web apps are almost never self-contained systems: we need to interact
+with external servers and data sources via RPC calls to get data from,
+and to mutate, the outside world.
+
+At runtime, a Bonsai app is a running incremental computation graph.
+Just like data cells in a spreadsheet, our graph will have mutable
+"source" nodes that are inputs to our incremental computation.
+
+These nodes are of type `'a Var.t`: the third main
 type in Bonsai. A var is similar to a `ref` or the analogous
 `'a Incr.Var.t` from incremental.
 
@@ -350,16 +308,19 @@ let view_for_counter : Vdom.Node.t Computation.t =
 ```
 # Bonsai is a compiler
 
-The `Bonsai` library does not provide the logic for stabilizing an
-incremental function and extracting the output value. Instead, it
-compiles the value and computation "surface syntax" into the "assembly
-language" provided by the `Incremental` library. Compilation happens
-once when the app starts up, and thereafter the main program only
+It might surprise you that Bonsai itself does not implement incremental
+computation OR a vdom runtime. That happens in the `Incremental` and
+`Virtual_dom` libraries, respectively.
+
+The `Bonsai` library provides syntax for describing the structure of an
+incremental state machine. It then compiles the value and computation
+"surface syntax" into the "assembly language" provided by the `Incremental` library.
+Compilation happens once when the app starts up, and thereafter the main program only
 interacts with the app in `Incr.t` form.
 
 The Bonsai API is carefully designed to allow its compiler to statically
-analyze the entire graph. This is why we [don't provide
-bind](../blogs/why_no_bind.md), since the callback passed to `bind` is
+analyze the entire computation graph. This is why we [don't provide
+a monadic bind](../blogs/why_no_bind.md), since the callback passed to `bind` is
 an opaque function. There are few important consequences of the static
 analyzability of Bonsai graphs:
 
@@ -370,3 +331,5 @@ analyzability of Bonsai graphs:
 -   We have the ability to instrument each node in a computation with
     performance and debugging info. Eventually we plan to use this info
     to implement a debugger and profiler for Bonsai computations.
+
+You can learn more about Bonsai as a general compiler for incremental state machines in [Bonsai Beyond the Web](11-beyond-web.md).

--- a/docs/guide/03-state.md
+++ b/docs/guide/03-state.md
@@ -5,6 +5,14 @@ computations capture internal state. This chapter takes a deeper look at
 the primitives Bonsai provides for introducing and interacting with
 local state.
 
+
+In this chapter, we'll:
+
+- Go over the `Bonsai.state` primitive in more depth
+- Show how stateful components can be instantiated multiple times, and when they will/won't share state
+- Introduce `Bonsai.state_machine`, which can better model complex state transition logic, and avoid bugs
+- Explain why stateful components are a good thing, from a functional programming perspective
+
 # Simple State
 
 The simplest kind of state is `Bonsai.state`. It returns both a value

--- a/docs/guide/03b-sharing_state.md
+++ b/docs/guide/03b-sharing_state.md
@@ -1,0 +1,75 @@
+# Sharing State
+
+<!-- I'm not sure if we want a section on this, so for now
+I've pretty much just copied what I wrote for my blog.
+If we want to keep this, I'd like to clean it up a bit,
+and come up with better use cases for global and dynamic scoped
+state.
+
+I'd also interleave the general introductions with the Bonsai
+explanations + examples.  -->
+
+In [chapter 3](03-state.md), we discussed some of Bonsai's primitives for
+storing and updating state within a single component. 
+
+Most non-trivial UIs will need to share state between components.
+There's a few patterns we can use, depending on what exactly we want to achieve.
+
+If state is shared between several components that are close together,
+we can store state in the "closest common ancestor" component,
+and pass it down through inputs to child components.
+See [React's Lifting State Up article](https://reactjs.org/docs/lifting-state-up.html) for examples.
+
+Sometimes, many components depend on some shared state/environment.
+For example, let's say we have a UI that can take on one of several themes.
+We don't want to hardcode a particular theme, so that users can change themes at will.
+We also don't want to explicitly pass the current theme as an argument to **every** component,
+since this would get messy fast. We could put it in a global variable (more on this later),
+but what if we want to build a "theme preview" system that shows the same component tree twice
+with different themes, side by side?
+
+For this case, we want to use something called **Context**, **Dynamic Scope,** or **Environment**, where a root component declares
+values for some semi-global state, which is then accessible to all the root's subcomponents.
+For more on this type of state-sharing, read about [React's Context](https://reactjs.org/docs/context.html).
+
+In other cases, we might have a global bit of state that is
+read/written to by two components that are very far apart.
+For example, we could have switches in a sidebar that controls
+some small part of a separate dashboard. We don't want to lift this state up,
+since it would need to be passed through many unrelated components.
+It also doesn't qualify as context, since it's only applicable to a few components.
+In this case, we'll want to put that state in a global variable,
+which will only be used by the related components.
+To be explicit about the behavior of this global variable,
+we could put it behind a model/action/apply_action pattern like
+the one provided by `Bonsai.state_machine`
+except that it would be available globally instead of in a single component.
+
+## Bonsai's Tools
+
+How can we implement these paradigms in Bonsai?
+
+"Lifting state up" is the simplest: a parent component can just
+pass state data/setters (wrapped in `Value.t`) to inner components as arguments when evaluating them.
+
+"Context" is done through the `Bonsai.Dynamic_scope` module.
+You can create an "environment" variable using `Dynamic_scope.create`,
+and access its value as a `Computation.t` with `Dynamic_scope.lookup`.
+Then, to evaluate a component tree with some value for a `Dynamic_scope` variable,
+you can call `Dynamic_scope.set env_var value ~inside:(tree_to_evaluate)`,
+which will return a new computation where all uses of `Dynamic_scope.lookup env_var`
+will return the set value.
+
+Global variables are a bit tricky. At first, you might think that you could
+just create a `Bonsai.state` and use it in several components,
+but recall that each `let%sub` instantiation of a `Computation.t`
+creates a new, unrelated instance. Instead, we can use a `Bonsai.Var`
+in the global scope to create a mutable variable that can be shared between components.
+If you want your components to re-render when the `Bonsai.Var.t` changes,
+make sure to access it via `Bonsai.Var.value var_instance`.
+
+Because Bonsai computations can return anything, not just vdom, we can also
+build components that return a view *and* some data, like we did when implementing
+textbox in the [state docs](03-state.md). This pattern is useful when only one component can
+write state, and one or more siblings need to read it. Although of course, you could return
+the `set_state` (or `inject` function) too.

--- a/docs/guide/11-beyond-web.md
+++ b/docs/guide/11-beyond-web.md
@@ -1,0 +1,18 @@
+# Bonsai Beyond the Web
+
+So far, we've talked about Bonsai solely as a library for building scalable
+and composable web UIs with OCaml. It may be surprising to know
+that Bonsai isn't specialized for user interfaces; rather, it answers
+the very generic question of how to build composable incremental
+state-machines. As it turns out, incremental state-machines are a great
+abstraction for building UI!
+
+Bonsai computations can produce anything; even in our web UIs, we've used
+plenty of `int Computation.t`, `string Computation.t`, and others. Unlike 
+React, computations around state and logic are first-class, just like those
+around vdom.
+
+<!-- 
+I think the VR and Wall integrations are definitely worth mentioning here,
+but are there other non-UI examples we could share?
+-->


### PR DESCRIPTION
# Bonsai Docs Feedback (WIP)

WIP: I still have about half the docs left to go through. Wanted to upload this as a draft PR in case I should change my approach.
 
Hi all! I've put together some feedback for the Bonsai docs in this PR. A lot of it is fairly crude; I'd like to make sure these suggestions are useful before focusing on refined wording or formatting.

I'm proposing some specific wording / structure changes in the pull request itself. This summary has a few more general suggestions relating to platform, naming, web presence, etc.

I’m assuming that the audience for these docs is familiar with web primitives (HTML, CSS, JavaScript), and has learned OCaml syntax. I'm trying not to assume any advanced knowledge in high-octane frontend development or arrow calculus.

## Naming Philosophy

One of the larger changes I'm proposing in the accompanying PR is moving away from the "Graph" vs "Output Node" analogy for Computation vs Value in favor of a variety of others, such as:

- code logic vs memory block where output is written
- React component class vs component class instance
- source code vs assembly output

While writing out my proposed changes, I've often found myself referring to `Computation.t` as a "Computation Blueprint" or "Computation Definition", and to `Value.t` as a "Computation Instance". In turn,  `Value.t` is a wrapper around an incrementally computed "raw value". This is confusing.

Assuming I'm understanding all this correctly, I think it would make sense to rename:

- `Computation.t` to `Blueprint.t`, making it clear that instances of `Computation.t` are definitions of computations, not computation instances.
- `Value.t` to `Computation.t` (or `Incr_value.t`, if we don't want to confuse current Bonsai users), since `Value.t`s ARE instances of incremental computations. This also avoids confusion with raw OCaml values.

## Single, Unified Platform

At the moment, docs for OSS Jane Street releases are scattered across several places:

- Brief "homepage" introductions on the [OSS website](https://opensource.janestreet.com/)
- "Root" `.mli`s, which provide references for library public APIs
- READMEs on GitHub
- The [Jane Street Tech Blog](https://blog.janestreet.com/)
- Assorted third-party guides and docs, e.g. [the OCaml forums](https://discuss.ocaml.org) and [blogs 😉](https://ceramichacker.com/)
- `docs` folders on GitHub, which contain `.mdx` files and are sometimes sub-organized further into "guides", "getting started tutorials", and "blog posts"

For new users, digging through a new (and not always intuitive) repository structure to find a starting point can be challenging. I think it might be worthwhile to make a centralized docs presence, which would have a subset of:

- A landing page, combining `README`s, the [OSS homepages](https://opensource.janestreet.com/), and [independent homepages](https://bonsai.red). This could include:
  - A brief code sample
  - A live example or video to showcase the power of the library. [Recoil](https://recoiljs.org/) does this very well
  - Links to external blogs and resources
  - A quick introduction of key points
- A chapter-based explanation, like [Bonsai's](https://github.com/janestreet/bonsai/tree/master/docs/guide), [Hardcaml's](https://github.com/janestreet/hardcaml/blob/master/docs/index.mdx), or [Incremental's](https://github.com/janestreet/incremental/tree/master/doc)
  - This can also include an unordered set of "advanced" articles, like Hardcaml does
- One or more "follow-along" tutorials, coupled with a scaffold that's easy to download and set up, or possibly an in-browser sandbox
- An unordered set of impromptu, self-contained blog posts, like the ones Bonsai has now
- An unordered set of "example" `.mlx` files, which would contain code blocks (with preview), and a little bit of explanatory text. This could be used to teach about common techniques and patterns, or document reusable components
- A link to the root `.mli`, and maybe [generated API docs](https://ocaml.org/p/base/v0.15.0/doc/Base/index.html)

I suspect it wouldn't be too difficult to write a library that generates static docs sites from a config file, which would run on every OSS release. The docs could then be hosted under `https://opensource.janestreet.com/`. This would:

- Make it easier for Jane Street libraries to release docs and publish them to the public
- Provide a centralized place for users to learn about any Jane Street library
- If we use a mature docs system like Docusaurus, we'll get a modern UI and search for free
- Help make internal docs more organized

Building a platform like this might be useful for internal users, and shouldn't significantly interrupt existing workflows. For internal usage, it might make sense to combine docs for all projects into a single "mono-doc site", which could help with global docs search and linking across projects. For example, I'm sure `let%...` docs are relevant to many libraries.

## Minor Miscellaneous Thoughts

- Is there a reason why we don't use let punning? It  would cut down on visual noise, reducing the "syntax boilerplate" needed to write Bonsai components.
- We do have a fairly diverse audience: web devs interested in OCaml, OCaml devs interested in web, Jane Street / Incremental devs who want a nice web UI,  etc. Maybe we should have several introductory pages depending on who you are? Maybe this could take the form of a dynamic homepage, leading to the same guide. Alternatively, we could have several short crash courses, which are then expanded on in the main guide. I like the "bonsai for incremental users" article we have now.
- We should consider embedding a very complex, probably contrived web UI example on the Bonsai landing page. This would showcase the performance and flexibility implications of Bonsai, and give users an example to play around with.
- In theory, it should be possible to create an in-browser sandbox (built with Bonsai??? :D). If it's not too slow to be useful, that could both help prototype/review new components, and be a useful learning tool.
- The "testing" docs seem to be missing; [effects](https://bonsai.red/05-effect.html) has a broken link at the bottom.
