### PR TITLE
fix: allow open source rpc chat example to compile

### DIFF
--- a/examples/open_source/rpc_chat/client/dune
+++ b/examples/open_source/rpc_chat/client/dune
@@ -1,4 +1,4 @@
-(executables (names main)
+(executables (names main) (modes js)
  (libraries async_kernel async_js core_kernel.composition_infix core
   bonsai_web bonsai_chat_open_source_common virtual_dom.input_widgets)
  (preprocess (pps js_of_ocaml-ppx ppx_jane)))


### PR DESCRIPTION
I'm assuming things work different with the internal build system, but the public release of dune needs this directive to output JavaScript. Also, without this, there's an error on use of any `Virtual_dom`:

```
File "_none_", line 1:             
Error: No implementations provided for the following modules:
         Ojs referenced from /home/askvortsov/.opam/janestreet-stable/lib/virtual_dom/virtual_dom.cmxa(Virtual_dom__Js_map),
           /home/askvortsov/.opam/janestreet-stable/lib/virtual_dom/virtual_dom.cmxa(Virtual_dom__Raw),
           /home/askvortsov/.opam/janestreet-stable/lib/virtual_dom/virtual_dom.cmxa(Virtual_dom__Attr)
```